### PR TITLE
Try to compensate for insufficient Q operations

### DIFF
--- a/lib/pdf/xpdf-changes.patch
+++ b/lib/pdf/xpdf-changes.patch
@@ -2565,15 +2565,26 @@
 
 --- xpdf-3.02_fix/Gfx.cc	2017-05-08 01:51:09.380121226 -0700
 +++ xpdf-3.02/Gfx.cc	2017-05-08 01:57:04.690898645 -0700
-@@ -3850,6 +3850,11 @@
-     out->endTransparencyGroup(state);
-   }
+@@ -3843,10 +3843,19 @@
+   // draw the form
+   display(str, gFalse);
  
++  // restore the old state, possibly popping leftover states by the form
++  while(state != old_state && state->hasSaves()) {
++    restoreState();
++  }
++
++  // it is possible that the form actually popped our state,
++  // in which case just bail out
 +  if (old_state != state) {
 +      error(getPos(), "There's a form with uneven q and Q operations");
 +      exit(-1);
 +  }
 +
-   // restore base matrix
-   for (i = 0; i < 6; ++i) {
-     baseMatrix[i] = oldBaseMatrix[i];
+   if (softMask || transpGroup) {
+-    // restore graphics state
+-    while(state != old_state)
+-	restoreState();
+     out->endTransparencyGroup(state);
+   }
+ 


### PR DESCRIPTION
A security patch ([#19](https://github.com/matthiaskramm/swftools/pull/19)) has rendered the conversion of some pdfs impossible as some XObjects contain unbalanced push (q) and pop (Q) commands on the graphics state stack.

As these PDFs can be opened by seemingly any PDF viewer, this PR attempts to fix this issue in a way that `pdf2swf` would accept and convert these PDFs without undoing the security fix.